### PR TITLE
build: upgrade third-party GitHub Actions to latest tags

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache for maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -48,14 +48,14 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
       - name: build (8)
         run: mvn -T 8 clean verify --no-transfer-progress -B -V
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: target-8
           path: target/*
@@ -66,9 +66,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -77,14 +77,14 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: build (11)
         run: mvn -T 8 clean verify -pl '!knox-agent' --no-transfer-progress -B -V
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: target-11
           path: target/*
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download build-8 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: target-8
       
@@ -107,7 +107,7 @@ jobs:
           cp version dev-support/ranger-docker/dist
 
       - name: Cache downloaded archives
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: dev-support/ranger-docker/downloads
           key: ${{ runner.os }}-ranger-downloads-${{ hashFiles('dev-support/ranger-docker/.env') }}


### PR DESCRIPTION
Automated bump of marketplace/public actions. Floating major pins (e.g. `v6`) are left as-is when the API reports a newer patch on the same major; cross-major upgrades use a floating major (`v6`) rather than a specific patch. Reusable workflow calls and branch pins are unchanged. Review CI before merge.